### PR TITLE
Fix for issue #78 

### DIFF
--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/IMqttConstants.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/IMqttConstants.java
@@ -24,4 +24,5 @@ public interface IMqttConstants {
 	public static final int UNINITIALIZED_KEEP_ALIVE_INTERVAL = -1;
 	public static final long CONSISTENT_REGION_DRAIN_WAIT_TIME = 180000;
 	public static final String MQTT_DEFAULT_DATA_ATTRIBUTE_NAME = "data";
+	public static final String COMMA = ",";
 }

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/MqttSinkOperator.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/MqttSinkOperator.java
@@ -307,10 +307,15 @@ public class MqttSinkOperator extends AbstractMqttOperator implements StateHandl
 		ConsistentRegionContext cContext = oContext.getOptionalContext(ConsistentRegionContext.class);
 		
 		if(cContext != null) {
-			TRACE.warn("Warning: Having a control port in a consistent region is not supported.  The control information may not be replayed, persisted and restored correctly.  You may need to manually replay the control signals to bring the operator back to a consistent state.");
+			List<StreamingInput<Tuple>> inputPorts = checker.getOperatorContext().getStreamingInputs();
+			
+			// if there is a control port, a warning message is issued as control port is not supported in a consistent region
+			if(inputPorts.size() > 1) {
+				TRACE.warn("Warning: Having a control port in a consistent region is not supported.  The control information may not be replayed, persisted and restored correctly.  You may need to manually replay the control signals to bring the operator back to a consistent state.");
+			}
 			
 			if(cContext.isStartOfRegion()) {
-				checker.setInvalidContext("ERROR: The following operator cannot be the start of a consistent region: [MQTTSink].", null);
+				checker.setInvalidContext("ERROR: The following operator cannot be the start of a consistent region: MQTTSink.", null);
 			}
 		}
 	}

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/SPLDocConstants.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/SPLDocConstants.java
@@ -19,8 +19,9 @@ public class SPLDocConstants {
 	static final String MQTTSRC_PARAM_TOPICATTRNAME_DESC = "Output attribute on output data stream to assign message topic to.";
 	static final String MQTTSRC_PARAM_ERRORATTRNAME_DESC = "Output attribute on optional error output port to assign error message to.";
 	static final String MQTTSRC_PARAM_SERVERIURI_DESC = "Server to subscribe messages from.";
-	static final String MQTTSRC_PARAM_QOS_DESC = "List of qos for topic subscriptions";
-	static final String MQTTSRC_PARAM_TOPICS_DESC = "List of topics to subscribe to.";
+	static final String MQTTSRC_PARAM_QOS_DESC = "List of qos for topic subscriptions, this attribute is mutually exclusive with qosStr attribute.";
+	static final String MQTTSRC_PARAM_QOS_STR_DESC = "List of qos in string format for topic subscriptions. Multiple comma separated qos value can be specified, for example \\\"0, 1\\\". This attribute is mutually exclusive with qos attribute.";
+	static final String MQTTSRC_PARAM_TOPICS_DESC = "List of topics to subscribe to. Multiple comma separated topics can be specified, for example \\\"topic1, topic2\\\"";
 	static final String MQTTSRC_PARAM_MESSAGE_SIZE_DESC = "Specify size of internal buffer for queueing incoming tuples. By default, internal buffer can hold up to 50 tuples.";
 
 	// SPL Documnetation for MQTTSink


### PR DESCRIPTION
Fix for issue #78. Also added new attribute qosStr allowing user to supply string of comma-separated qos. This new attribute qosStr is mutually exclusive with qos attribute.