### PR TITLE
Consistent region work for XMS operators. 

### DIFF
--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.xms/XMSSink/XMSSink.xml
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.xms/XMSSink/XMSSink.xml
@@ -11,6 +11,10 @@ The `XMSSink` operator takes messages from IBM InfoSphere Streams and can send t
 
 The incoming tuple from InfoSphere Streams can be one or many of the following data types: int8, uint8, int16, uint16, int32, uint32, int64, float32, float64, boolean, blob, or rstring. The input tuple is serialized into a WebSphere MQ message either as a map, stream, bytes, xml, wbe, or wbe22 message, according to the value of the message_class attribute in the connection specifications document. An additional empty value can be specified in the message_class attribute, in which case the operator constructs an empty JMS or XMS message. This message class cannot be used with a native schema.
 
+**Consistent Region Behavior**
+
+The `XMSSink` operator supports consistent region. This operator can be part of a consistent region but cannot be at start of a consistent region.
+
 **Exceptions**
 
 The following list describes the common types of exceptions that can occur:

--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.xms/XMSSink/XMSSink_cpp.cgt
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.xms/XMSSink/XMSSink_cpp.cgt
@@ -4,6 +4,11 @@
 # others. All Rights Reserved.                                    
 #######################################################################  
 %>
+
+<%
+   my $isInConsistentRegion = 
+   $model->getContext()->getOptionalContext("ConsistentRegion");
+%>
  
 <%
 # Set up commonly used variables
@@ -127,10 +132,24 @@ using namespace std;
 
 <%SPL::CodeGen::implementationPrologue($model);%>
 
+<%
+    ### Consistent region ERROR message ###
+    my $crContext = $model->getContext()->getOptionalContext("ConsistentRegion");
+    if($crContext && $crContext->isStartOfRegion()) {
+        SPL::CodeGen::exitln("The following operator cannot be the start of a consistent region: XMSSink");
+    }
+%>
+
 // Constructor
 MY_OPERATOR::MY_OPERATOR() : nTruncatedInserts(0),nTruncatedInsertsPC( getContext().getMetrics().getCustomMetricByName("nTruncatedInserts")),nFailedInserts(0),nFailedInsertsPC( getContext().getMetrics().getCustomMetricByName("nFailedInserts")),nConnectionAttempts(0),nConnectionAttemptsPC( getContext().getMetrics().getCustomMetricByName("nConnectionAttempts"))
 {
 	SPLAPPTRC(L_DEBUG, "Entry: Constructor", "XMSSink");
+	
+	<%if ($isInConsistentRegion) {%>
+	_crContext = static_cast<ConsistentRegionContext *> (getContext().getOptionalContext(CONSISTENT_REGION));
+	
+	getContext().registerStateHandler(*this);
+	<%}%>
 	
 	std::ostringstream ErrMsg;
 	
@@ -1023,5 +1042,31 @@ elsif ($msgType eq 'xml') { %>
 
 <% } %>
 
+<%if ($isInConsistentRegion) {%>
+
+void MY_OPERATOR::checkpoint(Checkpoint & ckpt)
+{
+	SPLAPPTRC(L_TRACE, "Checkpoint: " << ckpt.getSequenceId(), "CONSISTENT");
+}
+
+void MY_OPERATOR::reset(Checkpoint & ckpt)
+{
+   SPLAPPTRC(L_TRACE, "Reset: " << ckpt.getSequenceId(), "CONSISTENT");
+}
+
+void MY_OPERATOR::resetToInitialState()
+{
+    SPLAPPTRC(L_TRACE, "Reset to Initial State. ", "CONSISTENT");
+}
+
+void MY_OPERATOR::drain() {
+    SPLAPPTRC(L_TRACE, "Drain Operator", "CONSISTENT");
+}
+
+void MY_OPERATOR::retireCheckpoint(int64_t id) {
+	SPLAPPTRC(L_TRACE, "Retire Checkpoint: " << id, "CONSISTENT");
+}
+
+<%}%>
 
 <%SPL::CodeGen::implementationEpilogue($model);%>

--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.xms/XMSSink/XMSSink_h.cgt
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.xms/XMSSink/XMSSink_h.cgt
@@ -10,11 +10,21 @@
 #include <SPL/Runtime/Operator/OperatorMetrics.h>
 #include <SPL/Runtime/Common/Metric.h>
 
+<%
+   my $isInConsistentRegion = 
+     $model->getContext()->getOptionalContext("ConsistentRegion");
+   my @includes;
+   if ($isInConsistentRegion) {
+     push @includes, "#include <SPL/Runtime/Operator/State/StateHandler.h>";
+  }
+%>
 
 <%SPL::CodeGen::headerPrologue($model);%>
 
-
 class MY_OPERATOR : public MY_BASE_OPERATOR 
+<%if ($isInConsistentRegion) {%>
+, StateHandler
+<%}%>
 {
 
 public:
@@ -27,6 +37,15 @@ public:
 
 	// Tuple processing for non-mutating ports
 	void process(Tuple const & tuple, uint32_t port);
+	
+<%if ($isInConsistentRegion) {%>
+    // Callbacks from StateHandler.h
+    virtual void checkpoint(Checkpoint & ckpt);
+    virtual void reset(Checkpoint & ckpt);
+    virtual void resetToInitialState();
+    virtual void drain();
+    virtual void retireCheckpoint(int64_t id);
+<%}%> 
 
 private:
 
@@ -52,6 +71,10 @@ private:
 	boolean isErrorPortSpecified;
 	boolean isInitialConnectionFailure;
 	double periodVal;
+	
+<%if ($isInConsistentRegion) {%>
+    ConsistentRegionContext *_crContext;
+<%}%> 
 
 	/*******************************************************************
 	 * Class to help build the special XML format used for WBE messages *

--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.xms/XMSSource/XMSSource.xml
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.xms/XMSSource/XMSSource.xml
@@ -11,6 +11,10 @@ The `XMSSource` operator reads data from a WebSphere MQ queue or topic and creat
 
 Each input WebSphere MQ message is converted to a separate tuple and sent to the output stream. A single message cannot contain multiple tuples.
 
+**Consistent Region Behavior**
+
+The `XMSSource` operator cannot paticipate in a consistent region.
+
 **Exceptions**
 
 The following list describes the common types of exceptions that can occur:

--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.xms/XMSSource/XMSSource_cpp.cgt
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.xms/XMSSource/XMSSource_cpp.cgt
@@ -145,6 +145,13 @@ using namespace std;
 
 <%SPL::CodeGen::implementationPrologue($model);%>
 
+<%
+    ### Consistent region ERROR message ###
+    my $crContext = $model->getContext()->getOptionalContext("ConsistentRegion");
+    if($crContext) {
+        SPL::CodeGen::exitln("The following operator cannot be in a consistent region: XMSSource");
+    }
+%>
 
 // Constructor
 MY_OPERATOR::MY_OPERATOR(): nMessagesReadPC( getContext().getMetrics().getCustomMetricByName("nMessagesRead")),nMessagesDroppedPC( getContext().getMetrics().getCustomMetricByName("nMessagesDropped")),nConnectionAttemptsPC( getContext().getMetrics().getCustomMetricByName("nConnectionAttempts"))

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSink.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSink.java
@@ -285,7 +285,7 @@ public class JMSSink extends AbstractOperator implements StateHandler{
 		ConsistentRegionContext consistentRegionContext = checker.getOperatorContext().getOptionalContext(ConsistentRegionContext.class);
 		
 		if(consistentRegionContext != null && consistentRegionContext.isStartOfRegion()) {
-			checker.setInvalidContext("JMSSink operator can not be placed at start of a consistent region.", new String[] {});
+			checker.setInvalidContext("The following operator cannot be the start of a consistent region: JMSSink", new String[] {});
 		}
 	}
 

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSource.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSource.java
@@ -212,8 +212,8 @@ public class JMSSource extends ProcessTupleProducer {
 	public static void checkInConsistentRegion(OperatorContextChecker checker) {
 		ConsistentRegionContext consistentRegionContext = checker.getOperatorContext().getOptionalContext(ConsistentRegionContext.class);
 		
-		if(consistentRegionContext != null && consistentRegionContext.isStartOfRegion()) {
-			checker.setInvalidContext("JMSSource operator can not participate in a consistent region.", new String[] {});
+		if(consistentRegionContext != null) {
+			checker.setInvalidContext("The following operator cannot be in a consistent region: JMSSource", new String[] {});
 		}
 	}
 	/*

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/MqttSinkOperator.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/MqttSinkOperator.java
@@ -311,11 +311,11 @@ public class MqttSinkOperator extends AbstractMqttOperator implements StateHandl
 			
 			// if there is a control port, a warning message is issued as control port is not supported in a consistent region
 			if(inputPorts.size() > 1) {
-				TRACE.warn("Warning: Having a control port in a consistent region is not supported.  The control information may not be replayed, persisted and restored correctly.  You may need to manually replay the control signals to bring the operator back to a consistent state.");
+				TRACE.warn("Having a control port in a consistent region is not supported. The control information may not be replayed, persisted and restored correctly.  You may need to manually replay the control signals to bring the operator back to a consistent state.");
 			}
 			
 			if(cContext.isStartOfRegion()) {
-				checker.setInvalidContext("ERROR: The following operator cannot be the start of a consistent region: MQTTSink.", null);
+				checker.setInvalidContext("The following operator cannot be the start of a consistent region: MQTTSink.", null);
 			}
 		}
 	}

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/MqttSourceOperator.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/MqttSourceOperator.java
@@ -146,7 +146,7 @@ public class MqttSourceOperator extends AbstractMqttOperator {
 		ConsistentRegionContext cContext = oContext.getOptionalContext(ConsistentRegionContext.class);
 		
 		if(cContext != null) {
-			checker.setInvalidContext("WARNING: The following operator is not supported in a consistent region: MQTTSource. The operator does not checkpoint or reset its internal state. If an application failure occurs, the operator might produce unexpected results even if it is part of a consistent region.", new String[] {});
+			checker.setInvalidContext("The following operator cannot be in a consistent region: MQTTSource", new String[] {});
 		}
 	}
     


### PR DESCRIPTION
XMSSource does not support consistent region. XMSSink supports consistent region.

Changed warning and error message related to consistent region for JMS
and MQTT operators.