### PR TITLE
Toolkit version updated to 5.0.0

### DIFF
--- a/com.ibm.streamsx.messaging/info.xml
+++ b/com.ibm.streamsx.messaging/info.xml
@@ -680,7 +680,7 @@ The &lt;attribute&gt; element has three possible attributes:
      * composite types
      * xml
 </info:description>
-    <info:version>3.0.0</info:version>
+    <info:version>5.0.0</info:version>
     <info:requiredProductVersion>4.1.0.0</info:requiredProductVersion>
   </info:identity>
   <info:dependencies/>

--- a/samples/JMSSample/info.xml
+++ b/samples/JMSSample/info.xml
@@ -13,7 +13,7 @@ others. All Rights Reserved.
   <info:dependencies>
     <info:toolkit>
       <common:name>com.ibm.streamsx.messaging</common:name>
-      <common:version>[2.0.0,4.0.0)</common:version>
+      <common:version>[2.0.0,6.0.0)</common:version>
     </info:toolkit>
   </info:dependencies>
 </info:toolkitInfoModel>

--- a/samples/JmsWithXmlParse/info.xml
+++ b/samples/JmsWithXmlParse/info.xml
@@ -9,7 +9,7 @@
   <info:dependencies>
     <info:toolkit>
       <common:name>com.ibm.streamsx.messaging</common:name>
-      <common:version>[2.0.0,4.0.0)</common:version>
+      <common:version>[2.0.0,6.0.0)</common:version>
     </info:toolkit>
   </info:dependencies>
 </info:toolkitInfoModel>

--- a/samples/JmsWithXmlParseBytes/info.xml
+++ b/samples/JmsWithXmlParseBytes/info.xml
@@ -9,7 +9,7 @@
   <info:dependencies>
     <info:toolkit>
       <common:name>com.ibm.streamsx.messaging</common:name>
-      <common:version>[2.0.0,4.0.0)</common:version>
+      <common:version>[2.0.0,6.0.0)</common:version>
     </info:toolkit>
   </info:dependencies>
 </info:toolkitInfoModel>

--- a/samples/KafkaConsistentRegionConsumerParallel/info.xml
+++ b/samples/KafkaConsistentRegionConsumerParallel/info.xml
@@ -9,7 +9,7 @@
   <info:dependencies>
     <info:toolkit>
       <common:name>com.ibm.streamsx.messaging</common:name>
-      <common:version>[3.0.0,4.0.0)</common:version>
+      <common:version>[3.0.0,6.0.0)</common:version>
     </info:toolkit>
   </info:dependencies>
 </info:toolkitInfoModel>

--- a/samples/KafkaConsistentRegionConsumerSimple/info.xml
+++ b/samples/KafkaConsistentRegionConsumerSimple/info.xml
@@ -9,7 +9,7 @@
   <info:dependencies>
     <info:toolkit>
       <common:name>com.ibm.streamsx.messaging</common:name>
-      <common:version>[3.0.0,4.0.0)</common:version>
+      <common:version>[3.0.0,6.0.0)</common:version>
     </info:toolkit>
   </info:dependencies>
 </info:toolkitInfoModel>

--- a/samples/KafkaParallelConsumers/info.xml
+++ b/samples/KafkaParallelConsumers/info.xml
@@ -9,7 +9,7 @@
   <info:dependencies>
     <info:toolkit>
       <common:name>com.ibm.streamsx.messaging</common:name>
-      <common:version>[3.0.0,4.0.0)</common:version>
+      <common:version>[3.0.0,6.0.0)</common:version>
     </info:toolkit>
   </info:dependencies>
 </info:toolkitInfoModel>

--- a/samples/KafkaSample/info.xml
+++ b/samples/KafkaSample/info.xml
@@ -9,7 +9,7 @@
   <info:dependencies>
     <info:toolkit>
       <common:name>com.ibm.streamsx.messaging</common:name>
-      <common:version>[3.0.0,4.0.0)</common:version>
+      <common:version>[3.0.0,6.0.0)</common:version>
     </info:toolkit>
   </info:dependencies>
 </info:toolkitInfoModel>

--- a/samples/MqttSample/info.xml
+++ b/samples/MqttSample/info.xml
@@ -9,7 +9,7 @@
   <info:dependencies>
     <info:toolkit>
       <common:name>com.ibm.streamsx.messaging</common:name>
-      <common:version>[2.0.0,4.0.0)</common:version>
+      <common:version>[2.0.0,6.0.0)</common:version>
     </info:toolkit>
   </info:dependencies>
 </info:toolkitInfoModel>

--- a/samples/XMSSample/info.xml
+++ b/samples/XMSSample/info.xml
@@ -13,7 +13,7 @@ others. All Rights Reserved.
   <info:dependencies>
     <info:toolkit>
       <common:name>com.ibm.streamsx.messaging</common:name>
-      <common:version>[2.0.0,4.0.0)</common:version>
+      <common:version>[2.0.0,6.0.0)</common:version>
     </info:toolkit>
   </info:dependencies>
 </info:toolkitInfoModel>


### PR DESCRIPTION
1. Updated TK version to 5.0.0
2. Updated samples' required toolkit version range to support TK version update.