### PR TITLE
update activemq-client dependency to from 5.14.0 to 5.15.0

### DIFF
--- a/com.ibm.streamsx.messaging/.classpath
+++ b/com.ibm.streamsx.messaging/.classpath
@@ -9,7 +9,7 @@
 	<classpathentry kind="lib" path="opt/downloaded/hawtbuf-1.11.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/org.eclipse.paho.client.mqttv3-1.0.1.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/amqp-client-3.5.6.jar"/>
-	<classpathentry kind="lib" path="opt/downloaded/activemq-client-5.14.0-SNAPSHOT.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/activemq-client-5.15.0-SNAPSHOT.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/slf4j-api-1.7.13.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/kafka_2.11-0.9.0.1.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/kafka-clients-0.9.0.1.jar"/>

--- a/com.ibm.streamsx.messaging/pom.xml
+++ b/com.ibm.streamsx.messaging/pom.xml
@@ -43,7 +43,7 @@
 	  <dependency>
 	    <groupId>org.apache.activemq</groupId>
 	    <artifactId>activemq-client</artifactId>
-	    <version>5.14.0-SNAPSHOT</version>
+	    <version>5.15.0-SNAPSHOT</version>
 	  </dependency>
 	  <dependency>
 		  <groupId>com.rabbitmq</groupId>


### PR DESCRIPTION
The pom.xml and .classpath files have a hard-coded version number of 5.14.0 for the activemq-client.jar dependency. Unfortunately, 5.14.0 is no longer available from https://repository.apache.org/content/repositories/snapshots/org/apache/activemq/activemq-client/ . This updates the version number in the pom.xml and .classpath files to 5.15.0, which is the only version available in the Apache repository.