### PR TITLE
Add SSL support to JMS operators

### DIFF
--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSink/JMSSink.xml
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSink/JMSSink.xml
@@ -368,7 +368,7 @@ If the **maxMessageSendRetries** is specified, you must also specify a value for
       </parameter>
       <parameter>
         <name>keyStore</name>
-        <description>This parameter specifies the path to the keyStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *trustStore* and *keyStorePassword* parameters must also be set. </description>
+        <description>This parameter specifies the path to the keyStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect.</description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>rstring</type>
@@ -376,7 +376,7 @@ If the **maxMessageSendRetries** is specified, you must also specify a value for
       </parameter>
       <parameter>
         <name>keyStorePassword</name>
-        <description>This parameter specifies the password for the keyStore given by the *keyStore* parameter. The *sslConnection* parameter must be set to `true` for this parameter to have any effect. The *trustStore* and *keyStore* parameters must also be set. </description>
+        <description>This parameter specifies the password for the keyStore given by the *keyStore* parameter. The *sslConnection* parameter must be set to `true` for this parameter to have any effect.</description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>rstring</type>
@@ -384,7 +384,15 @@ If the **maxMessageSendRetries** is specified, you must also specify a value for
       </parameter>
       <parameter>
         <name>trustStore</name>
-        <description>This parameter specifies the path to the trustStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *keyStore* and *keyStorePassword* parameters must also be set. </description>
+        <description>This parameter specifies the path to the trustStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect.</description>
+        <optional>true</optional>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
+        <name>trustStorePassword</name>
+        <description>This parameter specifies the password for the trustStore given by the *trustStore* parameter. The *sslConnection* parameter must be set to `true` for this parameter to have any effect.</description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>rstring</type>

--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSink/JMSSink.xml
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSink/JMSSink.xml
@@ -19,6 +19,16 @@ For the `JMSSink` operator, the following message classes are supported:
 map, stream, bytes, xml, wbe, wbe22, and empty.
 The type of message is specified as the value of the message_class attribute in the connection specifications document.
 
+# SSL Support
+
+The `JMSSink` operator provides support for SSL via these parameters: *sslConnection*, *keyStore*, *keyStorePassword* and *trustStore*. 
+When *sslConnection* is set to `true`, the *keyStore*, *keyStorePassword* and *trustStore* parameters must be set. 
+
+**Note:** The `JMSSink` operator configures SSL by setting the JVM system properties via calls to `System.property()`. 
+Java operators that are fused into the same PE share the same JVM. This implies that any other Java operators fused into the 
+same PE as the `JMSSink` operator will have these SSL properties set. If this is undesirable, then the `JMSSink` operator
+should be placed into it's own PE. 
+
 # Behavior in a consistent region
 
 The `JMSSink` operator can be an operator within the reachability graph of a operator-driven consistent region.

--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSink/JMSSink.xml
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSink/JMSSink.xml
@@ -360,7 +360,7 @@ If the **maxMessageSendRetries** is specified, you must also specify a value for
       </parameter>
       <parameter>
         <name>sslConnection</name>
-        <description>This parameter specifies whether the operator should attempt to connect using SSL. If this parameter is specified, then the *keyStore*, *keyStorePassword* and *trustStore* parameters must also be specified. </description>
+        <description>This parameter specifies whether the operator should attempt to connect using SSL. If this parameter is specified, then the *keyStore*, *keyStorePassword* and *trustStore* parameters must also be specified. The default value of `false`.</description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>boolean</type>
@@ -368,7 +368,7 @@ If the **maxMessageSendRetries** is specified, you must also specify a value for
       </parameter>
       <parameter>
         <name>keyStore</name>
-        <description>This parameter specifies the path to the keyStore. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *trustStore* and *keyStorePassword* parameters must also be set. </description>
+        <description>This parameter specifies the path to the keyStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *trustStore* and *keyStorePassword* parameters must also be set. </description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>rstring</type>
@@ -384,7 +384,7 @@ If the **maxMessageSendRetries** is specified, you must also specify a value for
       </parameter>
       <parameter>
         <name>trustStore</name>
-        <description>This parameter specifies the path to the trustStore. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *keyStore* and *keyStorePassword* parameters must also be set. </description>
+        <description>This parameter specifies the path to the trustStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *keyStore* and *keyStorePassword* parameters must also be set. </description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>rstring</type>

--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSink/JMSSink.xml
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSink/JMSSink.xml
@@ -360,7 +360,7 @@ If the **maxMessageSendRetries** is specified, you must also specify a value for
       </parameter>
       <parameter>
         <name>sslConnection</name>
-        <description>This parameter specifies whether the operator should attempt to connect using SSL. If this parameter is specified, then the *keyStore*, *keyStorePassword* and *trustStore* parameters must also be specified. The default value of `false`.</description>
+        <description>This parameter specifies whether the operator should attempt to connect using SSL. If this parameter is specified, then the *keyStore*, *keyStorePassword* and *trustStore* parameters must also be specified. The default value is `false`.</description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>boolean</type>

--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSink/JMSSink.xml
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSink/JMSSink.xml
@@ -348,6 +348,38 @@ If the **maxMessageSendRetries** is specified, you must also specify a value for
         <type>rstring</type>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+        <name>sslConnection</name>
+        <description>This parameter specifies whether the operator should attempt to connect using SSL. If this parameter is specified, then the *keyStore*, *keyStorePassword* and *trustStore* parameters must also be specified. </description>
+        <optional>true</optional>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>boolean</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
+        <name>keyStore</name>
+        <description>This parameter specifies the path to the keyStore. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *trustStore* and *keyStorePassword* parameters must also be set. </description>
+        <optional>true</optional>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
+        <name>keyStorePassword</name>
+        <description>This parameter specifies the password for the keyStore given by the *keyStore* parameter. The *sslConnection* parameter must be set to `true` for this parameter to have any effect. The *trustStore* and *keyStore* parameters must also be set. </description>
+        <optional>true</optional>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
+        <name>trustStore</name>
+        <description>This parameter specifies the path to the trustStore. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *keyStore* and *keyStorePassword* parameters must also be set. </description>
+        <optional>true</optional>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSource/JMSSource.xml
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSource/JMSSource.xml
@@ -19,6 +19,17 @@ or a topic and creates tuples from the read data.
 The `JMSSource` operator converts each WebSphere MQ or Apache Active MQ message to a separate tuple
 and sends it to the output stream. A single message is converted into a single tuple.
 
+# SSL Support
+
+The `JMSSource` operator provides support for SSL via these parameters: *sslConnection*, *keyStore*, *keyStorePassword* and *trustStore*. 
+When *sslConnection* is set to `true`, the *keyStore*, *keyStorePassword* and *trustStore* parameters must be set. 
+
+**Note:** The `JMSSource` operator configures SSL by setting the JVM system properties via calls to `System.property()`. 
+Java operators that are fused into the same PE share the same JVM. This implies that any other Java operators fused into the 
+same PE as the `JMSSource` operator will have these SSL properties set. If this is undesirable, then the `JMSSource` operator
+should be placed into it's own PE. 
+ 
+
 # Behavior in a consistent region
 
 The `JMSSource` operator can participate in a consistent region. The operator must be at the start of a consistent region.

--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSource/JMSSource.xml
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSource/JMSSource.xml
@@ -356,7 +356,7 @@ This parameter must be greater than zero and must be set if the JMSSource operat
       </parameter>
       <parameter>
         <name>sslConnection</name>
-        <description>This parameter specifies whether the operator should attempt to connect using SSL. If this parameter is specified, then the *keyStore*, *keyStorePassword* and *trustStore* parameters must also be specified. The default value is `false`.S</description>
+        <description>This parameter specifies whether the operator should attempt to connect using SSL. If this parameter is specified, then the *keyStore*, *keyStorePassword* and *trustStore* parameters must also be specified. The default value is `false`.</description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>boolean</type>
@@ -364,7 +364,7 @@ This parameter must be greater than zero and must be set if the JMSSource operat
       </parameter>
       <parameter>
         <name>keyStore</name>
-        <description>This parameter specifies the path to the keyStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *trustStore* and *keyStorePassword* parameters must also be set. </description>
+        <description>This parameter specifies the path to the keyStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect.</description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>rstring</type>
@@ -372,7 +372,7 @@ This parameter must be greater than zero and must be set if the JMSSource operat
       </parameter>
       <parameter>
         <name>keyStorePassword</name>
-        <description>This parameter specifies the password for the keyStore given by the *keyStore* parameter. The *sslConnection* parameter must be set to `true` for this parameter to have any effect. The *trustStore* and *keyStore* parameters must also be set. </description>
+        <description>This parameter specifies the password for the keyStore given by the *keyStore* parameter. The *sslConnection* parameter must be set to `true` for this parameter to have any effect.</description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>rstring</type>
@@ -380,12 +380,20 @@ This parameter must be greater than zero and must be set if the JMSSource operat
       </parameter>
       <parameter>
         <name>trustStore</name>
-        <description>This parameter specifies the path to the trustStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *keyStore* and *keyStorePassword* parameters must also be set. </description>
+        <description>This parameter specifies the path to the trustStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect.</description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>rstring</type>
         <cardinality>1</cardinality>
-      </parameter>      
+      </parameter>  
+      <parameter>
+        <name>trustStorePassword</name>
+        <description>This parameter specifies the password for the trustStore given by the *trustStore* parameter. The *sslConnection* parameter must be set to `true` for this parameter to have any effect.</description>
+        <optional>true</optional>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>          
     </parameters>
     <inputPorts>
     </inputPorts>

--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSource/JMSSource.xml
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSource/JMSSource.xml
@@ -343,6 +343,38 @@ This parameter must be greater than zero and must be set if the JMSSource operat
         <type>rstring</type>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+        <name>sslConnection</name>
+        <description>This parameter specifies whether the operator should attempt to connect using SSL. If this parameter is specified, then the *keyStore*, *keyStorePassword* and *trustStore* parameters must also be specified. </description>
+        <optional>true</optional>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>boolean</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
+        <name>keyStore</name>
+        <description>This parameter specifies the path to the keyStore. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *trustStore* and *keyStorePassword* parameters must also be set. </description>
+        <optional>true</optional>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
+        <name>keyStorePassword</name>
+        <description>This parameter specifies the password for the keyStore given by the *keyStore* parameter. The *sslConnection* parameter must be set to `true` for this parameter to have any effect. The *trustStore* and *keyStore* parameters must also be set. </description>
+        <optional>true</optional>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
+        <name>trustStore</name>
+        <description>This parameter specifies the path to the trustStore. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *keyStore* and *keyStorePassword* parameters must also be set. </description>
+        <optional>true</optional>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>      
     </parameters>
     <inputPorts>
     </inputPorts>

--- a/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSource/JMSSource.xml
+++ b/com.ibm.streamsx.messaging/com.ibm.streamsx.messaging.jms/JMSSource/JMSSource.xml
@@ -356,7 +356,7 @@ This parameter must be greater than zero and must be set if the JMSSource operat
       </parameter>
       <parameter>
         <name>sslConnection</name>
-        <description>This parameter specifies whether the operator should attempt to connect using SSL. If this parameter is specified, then the *keyStore*, *keyStorePassword* and *trustStore* parameters must also be specified. </description>
+        <description>This parameter specifies whether the operator should attempt to connect using SSL. If this parameter is specified, then the *keyStore*, *keyStorePassword* and *trustStore* parameters must also be specified. The default value is `false`.S</description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>boolean</type>
@@ -364,7 +364,7 @@ This parameter must be greater than zero and must be set if the JMSSource operat
       </parameter>
       <parameter>
         <name>keyStore</name>
-        <description>This parameter specifies the path to the keyStore. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *trustStore* and *keyStorePassword* parameters must also be set. </description>
+        <description>This parameter specifies the path to the keyStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *trustStore* and *keyStorePassword* parameters must also be set. </description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>rstring</type>
@@ -380,7 +380,7 @@ This parameter must be greater than zero and must be set if the JMSSource operat
       </parameter>
       <parameter>
         <name>trustStore</name>
-        <description>This parameter specifies the path to the trustStore. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *keyStore* and *keyStorePassword* parameters must also be set. </description>
+        <description>This parameter specifies the path to the trustStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *keyStore* and *keyStorePassword* parameters must also be set. </description>
         <optional>true</optional>
         <expressionMode>AttributeFree</expressionMode>
         <type>rstring</type>

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSink.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSink.java
@@ -8,6 +8,9 @@ package com.ibm.streamsx.messaging.jms;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
 
 import javax.jms.Message;
@@ -190,7 +193,50 @@ public class JMSSink extends AbstractOperator implements StateHandler{
     // password property name stored in application configuration
     private String passwordPropName;
     
+    private String keyStore;
+    
+    private String trustStore;
+    
+    private String keyStorePassword;
+    
+    private boolean sslConnection;
 
+    public boolean isSslConnection() {
+		return sslConnection;
+	}
+
+    @Parameter(optional = true)
+    public void setSslConnection(boolean sslConnection) {
+		this.sslConnection = sslConnection;
+	}
+    
+    public String getTrustStore() {
+		return trustStore;
+	}
+    
+    @Parameter(optional = true)
+    public void setTrustStore(String trustStore) {
+		this.trustStore = trustStore;
+	}
+    
+    public String getKeyStorePassword() {
+		return keyStorePassword;
+	}
+    
+    @Parameter(optional = true)
+    public void setKeyStorePassword(String keyStorePassword) {
+		this.keyStorePassword = keyStorePassword;
+	}
+    
+    public String getKeyStore() {
+		return keyStore;
+	}
+    
+    @Parameter(optional = true)
+    public void setKeyStore(String keyStore) {
+		this.keyStore = keyStore;
+	}
+    
 	public String getAppConfigName() {
 		return appConfigName;
 	}
@@ -505,6 +551,21 @@ public class JMSSink extends AbstractOperator implements StateHandler{
 		checker.checkDependentParameters("passwordPropName", "appConfigName", "userPropName");
 	}
 
+	@ContextCheck(compile = false)
+	public static void checkSSLParameters(OperatorContextChecker checker) {
+		List<String> paramValues = checker.getOperatorContext().getParameterValues("sslConnection");
+		if(paramValues.size() > 0 && Boolean.valueOf(paramValues.get(0)) == true) {
+			Set<String> params = checker.getOperatorContext().getParameterNames();
+				
+			if(!params.contains("keyStore") 
+					|| !params.contains("trustStore") 
+					|| !params.contains("keyStorePassword")) {
+				String msg = "The 'keyStore', 'trustStore' and 'keyStorePassword' parameters must be set when 'sslConnection' is set to true."; 
+				checker.setInvalidContext(msg, null);;
+			}
+		}
+	}
+	
 	@Override
 	public synchronized void initialize(OperatorContext context)
 			throws ParserConfigurationException, InterruptedException,
@@ -513,6 +574,13 @@ public class JMSSink extends AbstractOperator implements StateHandler{
 		super.initialize(context);
 		
 		JmsClasspathUtil.setupClassPaths(context);
+		
+		// set SSL system properties
+		if(isSslConnection()) {
+			System.setProperty("javax.net.ssl.keyStore", getKeyStore());
+			System.setProperty("javax.net.ssl.keyStorePassword", getKeyStorePassword());
+			System.setProperty("javax.net.ssl.trustStore",  getTrustStore());			
+		}
 		
 		consistentRegionContext = context.getOptionalContext(ConsistentRegionContext.class);
 		
@@ -627,7 +695,6 @@ public class JMSSink extends AbstractOperator implements StateHandler{
 
 		// register for data governance
 		registerForDataGovernance(connectionDocumentParser.getProviderURL(), connectionDocumentParser.getDestination());
-
 	}
 
 	private void registerForDataGovernance(String providerURL, String destination) {

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSink.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSink.java
@@ -8,6 +8,9 @@ package com.ibm.streamsx.messaging.jms;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -577,9 +580,9 @@ public class JMSSink extends AbstractOperator implements StateHandler{
 		
 		// set SSL system properties
 		if(isSslConnection()) {
-			System.setProperty("javax.net.ssl.keyStore", getKeyStore());
+			System.setProperty("javax.net.ssl.keyStore", getAbsolutePath(getKeyStore()));
 			System.setProperty("javax.net.ssl.keyStorePassword", getKeyStorePassword());
-			System.setProperty("javax.net.ssl.trustStore",  getTrustStore());			
+			System.setProperty("javax.net.ssl.trustStore",  getAbsolutePath(getTrustStore()));			
 		}
 		
 		consistentRegionContext = context.getOptionalContext(ConsistentRegionContext.class);
@@ -697,6 +700,20 @@ public class JMSSink extends AbstractOperator implements StateHandler{
 		registerForDataGovernance(connectionDocumentParser.getProviderURL(), connectionDocumentParser.getDestination());
 	}
 
+	protected String getAbsolutePath(String filePath) {
+		if(filePath == null) 
+			return null;
+		
+		
+		Path p = Paths.get(filePath);
+		if(p.isAbsolute()) {
+			return filePath;
+		} else {
+			File f = new File (getOperatorContext().getPE().getApplicationDirectory(), filePath);
+			return f.getAbsolutePath();
+		}
+	}
+	
 	private void registerForDataGovernance(String providerURL, String destination) {
 		logger.log(TraceLevel.INFO, "JMSSink - Registering for data governance with providerURL: " + providerURL
 				+ " destination: " + destination);

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSource.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSource.java
@@ -9,6 +9,9 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -609,9 +612,9 @@ public class JMSSource extends ProcessTupleProducer implements StateHandler{
 		
 		// set SSL system properties
 		if(isSslConnection()) {
-			System.setProperty("javax.net.ssl.keyStore", getKeyStore());
+			System.setProperty("javax.net.ssl.keyStore", getAbsolutePath(getKeyStore()));
 			System.setProperty("javax.net.ssl.keyStorePassword", getKeyStorePassword());
-			System.setProperty("javax.net.ssl.trustStore",  getTrustStore());			
+			System.setProperty("javax.net.ssl.trustStore",  getAbsolutePath(getTrustStore()));			
 		}
 		
 		if(consistentRegionContext != null) {
@@ -696,6 +699,20 @@ public class JMSSource extends ProcessTupleProducer implements StateHandler{
 
 	}
 
+	protected String getAbsolutePath(String filePath) {
+		if(filePath == null) 
+			return null;
+		
+		Path p = Paths.get(filePath);
+		if(p.isAbsolute()) {
+			return filePath;
+		} else {
+			File f = new File (getOperatorContext().getPE().getApplicationDirectory(), filePath);
+			System.out.println(f);
+			return f.getAbsolutePath();
+		}
+	}
+	
 	private void registerForDataGovernance(String providerURL, String destination) {
 		logger.log(TraceLevel.INFO, "JMSSource - Registering for data governance with providerURL: " + providerURL
 				+ " destination: " + destination);

--- a/com.ibm.streamsx.messaging/info.xml
+++ b/com.ibm.streamsx.messaging/info.xml
@@ -680,7 +680,7 @@ The &lt;attribute> element has three possible attributes:
      * composite types
      * xml
 </info:description>
-    <info:version>5.1.0</info:version>
+    <info:version>5.2.0</info:version>
     <info:requiredProductVersion>4.2.0.0</info:requiredProductVersion>
   </info:identity>
   <info:dependencies/>


### PR DESCRIPTION
This pull request adds the following parameters to the JMSSource and JMSSink operators in order to support SSL connections.

 * **sslConnection** -  This parameter specifies whether the operator should attempt to connect using SSL. If this parameter is specified, then the *keyStore*, *keyStorePassword* and *trustStore* parameters must also be specified. The default value is `false`.
 * **keyStore** - This parameter specifies the path to the keyStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *trustStore* and *keyStorePassword* parameters must also be set.
 * **keyStorePassword** - This parameter specifies the password for the keyStore given by the *keyStore* parameter. The *sslConnection* parameter must be set to `true` for this parameter to have any effect. The *trustStore* and *keyStore* parameters must also be set.
 * **trustStore** - This parameter specifies the path to the trustStore. If a relative path is specified, the path is relative to the application directory. The *sslConnection* parameter must be set to true for this parameter to have any effect. The *keyStore* and *keyStorePassword* parameters must also be set.

The toolkit version has also been moved up to 5.2.0.  