### PR TITLE
[WIP] Ensuring at least once with consistent region

### DIFF
--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/AttributeHelper.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/AttributeHelper.java
@@ -96,21 +96,21 @@ class AttributeHelper {
 		}
 	}
 	
-	String getString(Tuple tuple) throws IOException {
+	String getString(Tuple tuple) {
 		if(!isAvailable) return null;
 		if(isString)
 			return tuple.getString(name);
         return new String(getBytesFromBlob(tuple, name));
 	}
 	
-	byte[] getBytes(Tuple tuple) throws IOException {
+	byte[] getBytes(Tuple tuple) {
 		if(!isAvailable) return null;
 		if(isString)
 			return tuple.getString(name).getBytes(CS);
 		return getBytesFromBlob(tuple, name);
 	}
 	
-	private static byte[] getBytesFromBlob(Tuple tuple, String name) throws IOException {
+	private static byte[] getBytesFromBlob(Tuple tuple, String name) {
 		Blob blockMsg = tuple.getBlob(name);
 		ByteBuffer msgBuffer = blockMsg.getByteBuffer();
 		byte[] msgBytes = new byte[(int) blockMsg.getLength()];

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/KafkaProducerClient.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/KafkaProducerClient.java
@@ -54,7 +54,7 @@ class ProducerStringHelper extends KafkaProducerClient{
 	}
 
 	@Override
-	void send(Tuple tuple) throws Exception {
+	void send(Tuple tuple) {
 		String topic = topicAH.getString(tuple);
 		String message = messageAH.getString(tuple);
 		String key = keyAH.getString(tuple);
@@ -64,7 +64,7 @@ class ProducerStringHelper extends KafkaProducerClient{
 	}
 
 	@Override
-	void send(Tuple tuple, List<String> topics) throws Exception {
+	void send(Tuple tuple, List<String> topics) {
 		String message = messageAH.getString(tuple);
 		String key = keyAH.getString(tuple);
 

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/KafkaProducerClient.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/KafkaProducerClient.java
@@ -6,57 +6,49 @@ package com.ibm.streamsx.messaging.kafka;
 
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.Future;
 
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+
 import com.ibm.streams.operator.Tuple;
 import com.ibm.streams.operator.logging.TraceLevel;
 
 public abstract class KafkaProducerClient extends KafkaBaseClient {
-	protected AtomicBoolean messageException = new AtomicBoolean(false);
 	
-	public KafkaProducerClient(AttributeHelper topicAH, AttributeHelper keyAH,
+    final Callback callback;
+    final List<Future<RecordMetadata>> sentMessages;
+
+	
+	public KafkaProducerClient(
+	        Callback callback,
+	        List<Future<RecordMetadata>> sentMessages,
+	        AttributeHelper topicAH, AttributeHelper keyAH,
 			AttributeHelper messageAH, Properties props){
 		super(topicAH, keyAH, messageAH, props);
+		this.callback = callback;
+	    this.sentMessages = sentMessages;
+
 		props = KafkaConfigUtilities.setDefaultSerializers(keyAH, messageAH, props);
 	}
 
 	abstract void send(Tuple tuple, List<String> topics) throws Exception;
 
 	abstract void send(Tuple tuple) throws Exception;
-	
-	public boolean hasMessageException() {
-		return messageException.get();
-	}
-	
-	protected Callback getMessageCallback() {
-		return new Callback() {
-            public void onCompletion(RecordMetadata metadata, Exception e) {
-                if(e != null){
-                    e.printStackTrace();
-                    trace.log(TraceLevel.ERROR, "Message exception: " + e.getMessage());
-	                messageException.set(true);
-                }
-            }
-        };
-	}
-
-	public void resetMessageException() {
-		 messageException.set(false);
-	}
-
 }
 
 class ProducerStringHelper extends KafkaProducerClient{
 
 	private KafkaProducer<String, String> producer = null;
 	
-	public ProducerStringHelper(AttributeHelper topicAH, AttributeHelper keyAH,
+	public ProducerStringHelper(
+	        Callback callback,
+	        List<Future<RecordMetadata>> sentMessages,
+	        AttributeHelper topicAH, AttributeHelper keyAH,
 			AttributeHelper messageAH, Properties props) {
-		super(topicAH, keyAH, messageAH, props);
+		super(callback, sentMessages, topicAH, keyAH, messageAH, props);
 		producer = new KafkaProducer<String, String>(props);
 		trace.log(TraceLevel.INFO, "Creating producer of type KafkaProducer\\<String,String\\>" );
 	}
@@ -67,7 +59,8 @@ class ProducerStringHelper extends KafkaProducerClient{
 		String message = messageAH.getString(tuple);
 		String key = keyAH.getString(tuple);
 		
-		producer.send(new ProducerRecord<String, String>(topic ,key, message),  getMessageCallback());
+		sentMessages.add(
+		        producer.send(new ProducerRecord<String, String>(topic ,key, message),  callback));
 	}
 
 	@Override
@@ -76,8 +69,9 @@ class ProducerStringHelper extends KafkaProducerClient{
 		String key = keyAH.getString(tuple);
 
 		for(String topic : topics) {
-			producer.send(new ProducerRecord<String, String>(topic ,key, message), 
-					getMessageCallback());
+		    sentMessages.add(
+			    producer.send(new ProducerRecord<String, String>(topic ,key, message), 
+					callback));
 		}
 
 	}
@@ -93,9 +87,11 @@ class ProducerStringHelper extends KafkaProducerClient{
 class ProducerByteHelper extends KafkaProducerClient{
 	private KafkaProducer<byte[],byte[]> producer = null;
 	
-	public ProducerByteHelper(AttributeHelper topicAH, AttributeHelper keyAH,
+	public ProducerByteHelper(
+	        Callback callback, List<Future<RecordMetadata>> sentMessages,
+	        AttributeHelper topicAH, AttributeHelper keyAH,
 			AttributeHelper messageAH, Properties props) {
-		super(topicAH, keyAH, messageAH, props);
+		super(callback, sentMessages, topicAH, keyAH, messageAH, props);
 		producer = new KafkaProducer<byte[],byte[]>(props);
 		trace.log(TraceLevel.INFO, "Creating producer of type KafkaProducer\\<Byte,Byte\\>" );
 	}
@@ -107,8 +103,9 @@ class ProducerByteHelper extends KafkaProducerClient{
 		byte [] message = messageAH.getBytes(tuple);
 		byte [] key = keyAH.getBytes(tuple);
 
-		producer.send(new ProducerRecord<byte[],byte[]>(topic ,key, message), 
-				getMessageCallback());
+		sentMessages.add(
+		   producer.send(new ProducerRecord<byte[],byte[]>(topic ,key, message), 
+				callback));
 	}
 
 	@Override
@@ -117,8 +114,9 @@ class ProducerByteHelper extends KafkaProducerClient{
 		byte [] key = keyAH.getBytes(tuple);
 
 		for(String topic : topics) {
-			producer.send(new ProducerRecord<byte[],byte[]>(topic,key, message), 
-					getMessageCallback());
+		    sentMessages.add(
+		        producer.send(new ProducerRecord<byte[],byte[]>(topic,key, message), 
+					callback));
 		}
 
 	}

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/KafkaProducerFactory.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/KafkaProducerFactory.java
@@ -4,8 +4,13 @@
  *******************************************************************************/
 package com.ibm.streamsx.messaging.kafka;
 
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.Future;
 import java.util.logging.Logger;
+
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.RecordMetadata;
 
 import com.ibm.streams.operator.logging.TraceLevel;
 
@@ -14,14 +19,16 @@ public class KafkaProducerFactory {
 	private final Logger trace = Logger.getLogger(KafkaProducerFactory.class
 			.getCanonicalName());
 	
-	public KafkaProducerClient getClient(AttributeHelper topicAH,
+	public KafkaProducerClient getClient(
+	        Callback callback, List<Future<RecordMetadata>> sentMessages,
+	        AttributeHelper topicAH,
 			AttributeHelper keyAH, AttributeHelper messageAH, Properties props) {
 		if (messageAH.isString() && (!keyAH.isAvailable() || keyAH.isString())){
 			trace.log(TraceLevel.WARNING, "Using KafkaProducer<String,String> client.");
-			client = new ProducerStringHelper(topicAH, keyAH, messageAH, props);
+			client = new ProducerStringHelper(callback, sentMessages, topicAH, keyAH, messageAH, props);
 		} else if ( !messageAH.isString() && (!keyAH.isAvailable() || !keyAH.isString())){
 			trace.log(TraceLevel.WARNING, "Using KafkaProducer<byte,byte> client.");
-			client = new ProducerByteHelper(topicAH, keyAH, messageAH, props);
+			client = new ProducerByteHelper(callback, sentMessages, topicAH, keyAH, messageAH, props);
 		} else {
 			trace.log(TraceLevel.ERROR, "Key and Message type must match and be of type String or Byte.");
 		}

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/KafkaSink.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/KafkaSink.java
@@ -5,15 +5,26 @@
 
 package com.ibm.streamsx.messaging.kafka;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
+
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.RecordMetadata;
 
 import com.ibm.streams.operator.OperatorContext;
 import com.ibm.streams.operator.OperatorContext.ContextCheck;
 import com.ibm.streams.operator.StreamSchema;
+import com.ibm.streams.operator.StreamingData.Punctuation;
 import com.ibm.streams.operator.StreamingInput;
 import com.ibm.streams.operator.Tuple;
 import com.ibm.streams.operator.compile.OperatorContextChecker;
@@ -23,7 +34,9 @@ import com.ibm.streams.operator.model.InputPortSet;
 import com.ibm.streams.operator.model.InputPorts;
 import com.ibm.streams.operator.model.Parameter;
 import com.ibm.streams.operator.model.PrimitiveOperator;
+import com.ibm.streams.operator.state.Checkpoint;
 import com.ibm.streams.operator.state.ConsistentRegionContext;
+import com.ibm.streams.operator.state.StateHandler;
 import com.ibm.streamsx.messaging.common.DataGovernanceUtil;
 import com.ibm.streamsx.messaging.common.IGovernanceConstants;
 
@@ -32,13 +45,20 @@ import com.ibm.streamsx.messaging.common.IGovernanceConstants;
 			"Out of these \\\"message\\\", is a required attribute."))
 @PrimitiveOperator(name=KafkaSink.OPER_NAME, description=KafkaSink.DESC)
 @Icons(location16="icons/KafkaProducer_16.gif", location32="icons/KafkaProducer_32.gif")
-public class KafkaSink extends KafkaBaseOper {
+public class KafkaSink extends KafkaBaseOper implements StateHandler, Callback {
 	
 	
 	static final String OPER_NAME =  "KafkaProducer";
 	
 	private static final Logger trace = Logger.getLogger(KafkaSink.class.getName());
 	private KafkaProducerClient producerClient;
+	
+	// Sent messages that have not been sent to the broker by
+	// the client.
+	private final List<Future<RecordMetadata>> sentMessages =
+	        Collections.synchronizedList(new LinkedList<>());
+	private Exception sentMessageException; // synchronized by sentMessages
+	private AtomicBoolean clientSeenException = new AtomicBoolean();
 	
 	@Parameter(name="topic", cardinality=-1, optional=true, 
 			description="Topic to be published to. A topic can also be specified as an input stream attribute.")
@@ -101,9 +121,9 @@ public class KafkaSink extends KafkaBaseOper {
 		registerForDataGovernance();
 	}
 	
-	private static KafkaProducerClient getNewProducerClient(AttributeHelper topicAH, AttributeHelper keyAH, AttributeHelper messageAH, Properties finalProperties) {
+	private KafkaProducerClient getNewProducerClient(AttributeHelper topicAH, AttributeHelper keyAH, AttributeHelper messageAH, Properties finalProperties) {
 		KafkaProducerFactory producerFactory = new KafkaProducerFactory();
-		KafkaProducerClient producerClient = producerFactory.getClient(topicAH, keyAH, messageAH, finalProperties);
+		KafkaProducerClient producerClient = producerFactory.getClient(this, sentMessages, topicAH, keyAH, messageAH, finalProperties);
 		return producerClient;
 	}
 
@@ -123,7 +143,7 @@ public class KafkaSink extends KafkaBaseOper {
 	}
 	
 	@Override
-	public void process(StreamingInput<Tuple> stream, Tuple tuple) throws FileNotFoundException, IOException, UnsupportedStreamsKafkaConfigurationException{
+	public void process(StreamingInput<Tuple> stream, Tuple tuple) throws Exception {
 		try {	
 			if(trace.isLoggable(TraceLevel.DEBUG))
 				trace.log(TraceLevel.DEBUG, "Sending message: " + tuple);
@@ -138,14 +158,25 @@ public class KafkaSink extends KafkaBaseOper {
 			resetProducerIfPropertiesHaveChanged();
 		}
 		
-		if(producerClient.hasMessageException() == true){
+		if (clientSeenException.get()){
 			trace.log(TraceLevel.WARN, "Found message exception");
 			resetProducerIfPropertiesHaveChanged();
 		}
 
 	}
+	
+	// If no more tuples are expected then make sure
+	// the messages make it to the broker before
+	// shutting down.
+	@Override
+	public void processPunctuation(StreamingInput<Tuple> stream, Punctuation mark) throws Exception {
+	    if (mark == Punctuation.FINAL_MARKER)
+	        drain();
+	}
+	
+	
 	private void resetProducerIfPropertiesHaveChanged()
-			throws FileNotFoundException, IOException, UnsupportedStreamsKafkaConfigurationException {
+			throws Exception {
 		OperatorContext context = this.getOperatorContext();
 		if (newPropertiesExist(context)){
 			trace.log(TraceLevel.INFO,
@@ -153,11 +184,14 @@ public class KafkaSink extends KafkaBaseOper {
 			resetProducerClient(context);
 		} else {
 			trace.log(TraceLevel.INFO, "Properties have not changed, so we are keeping the same producer client and resetting the message exception.");
-			producerClient.resetMessageException();
 		}
+		clientSeenException.set(false);
 	}
 
-	private void resetProducerClient(OperatorContext context) throws FileNotFoundException, IOException, UnsupportedStreamsKafkaConfigurationException {
+	private void resetProducerClient(OperatorContext context) throws Exception {
+	    
+	    // Drain outstanding messages from the existing producer
+	    drain();
 		
 		// Not catching exceptions because we want to fail
 		// if we can't initialize a new producer
@@ -165,6 +199,125 @@ public class KafkaSink extends KafkaBaseOper {
 		producerClient.shutdown();
 		producerClient = getNewProducerClient(topicAH, keyAH, messageAH, finalProperties);
 	}
+	
+	/**
+	 * Delegate the removal of the task to a task to avoid any
+	 * blocking or excessive processing on the Kafka I/O thread.
+	 */
+    @Override
+    public void onCompletion(RecordMetadata rmd, Exception exception) {
+        getOperatorContext().getScheduledExecutorService().submit(() -> handleCompletedMessage(rmd, exception));
+    }
+
+    /**
+     * Handle a completed message. The callback cannot be tied
+     * to a Future so just clean out any completed messages.
+     */
+    private Object handleCompletedMessage(RecordMetadata rmd, Exception exception) throws Exception {
+
+        synchronized (sentMessages) {
+            if (exception != null) {
+                if (sentMessageException == null)
+                    sentMessageException = exception;
+            }
+
+            final Iterator<Future<RecordMetadata>> it = sentMessages.iterator();
+            while (it.hasNext()) {
+                Future<RecordMetadata> sentMessage = it.next();
+                try {
+                    sentMessage.get(0, MILLISECONDS);
+                } catch (TimeoutException e) {
+                    // reached a non-completed message
+                    // with the assumption messages are
+                    // completed in order then stop
+                    // looking for completed messages.
+                    break;
+                } catch (ExecutionException ee) {
+                    trace.log(TraceLevel.ERROR, "Sending message failed", ee.getCause());
+
+                    if (sentMessageException == null)
+                        exception = ee;
+                    // remove from list
+                }
+                it.remove();
+            }
+        }
+        if (exception != null)
+            throw exception;
+
+        return null;
+    }
+	
+	/**
+     * Ensure any sent messages have been received by 
+     * the broker according to the setting of the
+     * Kafka ack configuration property.
+     */
+    @Override
+    public void drain() throws Exception {
+
+        outer: while (!sentMessages.isEmpty()) {
+
+            synchronized (sentMessages) {
+                
+                if (sentMessageException != null)
+                    throw sentMessageException;
+                
+                // Remove any completed messages, if there was an
+                // exception then Future.get will throw an exception
+                // causing the region to reset.
+                final Iterator<Future<RecordMetadata>> it = sentMessages.iterator();
+                while (it.hasNext()) {
+                    Future<RecordMetadata> sentMessage = it.next();
+                    try {
+                        sentMessage.get(1, MILLISECONDS);
+                    } catch (TimeoutException e) {
+                        // Continue from the start of the
+                        // list as it is expected messages
+                        // will complete in order. And we don't
+                        // wait to wait potentially for
+                        // each unfinished message as the
+                        // time could be up to N ms where
+                        // N is the number of sent but
+                        // not completed messages.
+                        continue outer;
+                    }
+                    it.remove();
+                }
+            }
+        }
+    
+        synchronized (sentMessages) {
+            if (sentMessageException != null)
+                throw sentMessageException;
+        }
+    }
+    @Override
+    public void checkpoint(Checkpoint checkpoint) {
+        // nothing to save
+    }
+    @Override
+    public void reset(Checkpoint checkpoint) {
+        // Forget about any messages already sent.
+        resetToInitialState();
+    }
+    @Override
+    public void resetToInitialState() {
+        // Forget about any messages already sent.
+        synchronized (sentMessages) {
+            sentMessageException = null;
+            sentMessages.clear();
+        }
+        
+    }
+    @Override
+    public void retireCheckpoint(long id) {
+        // nothing to do.
+    }
+    @Override
+    public void close() {
+        // handled by shutdown     
+    }
 
 	public static final String DESC = 
 			"This operator acts as a Kafka producer sending tuples as messages to a Kafka broker. " + 
@@ -177,4 +330,6 @@ public class KafkaSink extends KafkaBaseOper {
 			"\\nThis operator can participate in a consistent region.  This operator cannot be placed at the start of a consistent region. "
 			+ "The KafkaProducer guarantees at-least-once delivery of messages to a Kafka topic."
 			;
+
+
 }

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/KafkaSink.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/KafkaSink.java
@@ -336,17 +336,28 @@ public class KafkaSink extends KafkaBaseOper implements StateHandler, Callback {
     }
     @Override
     public void reset(Checkpoint checkpoint) {
-        // Forget about any messages already sent.
         resetToInitialState();
     }
     @Override
     public void resetToInitialState() {
-        // Forget about any messages already sent.
+        // Forget about any messages already sent
+        // trying to cancel if they are not yet sent.
         synchronized (sentMessages) {
+            
+            if (trace.isLoggable(TRACE)) {
+                trace.log(TRACE, "reset:outstanding messages:" + sentMessages.size());
+            }
+
+            for (Future<RecordMetadata> sentMessage : sentMessages) {
+                sentMessage.cancel(false);             
+            }
+            
+            if (trace.isLoggable(TRACE)) {
+                trace.log(TRACE, "reset:cancelled outstanding messages");
+            }
             sentMessageException = null;
             sentMessages.clear();
         }
-        
     }
     @Override
     public void retireCheckpoint(long id) {

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/KafkaSink.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/kafka/KafkaSink.java
@@ -145,19 +145,14 @@ public class KafkaSink extends KafkaBaseOper implements StateHandler, Callback {
 	
 	@Override
 	public void process(StreamingInput<Tuple> stream, Tuple tuple) throws Exception {
-		try {	
-			if(trace.isLoggable(TraceLevel.DEBUG))
-				trace.log(TraceLevel.DEBUG, "Sending message: " + tuple);
-			
-			if(!topics.isEmpty()) 
-				producerClient.send(tuple, topics);
-			else 
-				producerClient.send(tuple);
-		} catch(Exception e) {
-			trace.log(TraceLevel.ERROR, "Could not send message: " + tuple, e);
-			e.printStackTrace();
-			resetProducerIfPropertiesHaveChanged();
-		}
+	
+        if (trace.isLoggable(TraceLevel.DEBUG))
+            trace.log(TraceLevel.DEBUG, "Sending message: " + tuple);
+
+        if (!topics.isEmpty())
+            producerClient.send(tuple, topics);
+        else
+            producerClient.send(tuple);
 		
 		if (clientSeenException.get()){
 			trace.log(TraceLevel.WARN, "Found message exception");


### PR DESCRIPTION
* Maintain futures of sent messages
* Implement drain to wait for all messages to be sent to the broker
* Also call drain on a final marker to ensure messages are flushed before any shutdown.
* Ensure any exception during processing will cause a drain to fail

Still to be done:
* Correct exception handling in a consistent region