### PR TITLE
Update KafkaSASLSample for Kafka 0.10

### DIFF
--- a/samples/KafkaSASLSample/etc/consumer.properties
+++ b/samples/KafkaSASLSample/etc/consumer.properties
@@ -2,6 +2,7 @@ bootstrap.servers=broker.host.1:9092,broker.host.2:9092,broker.host.3:9092
 group.id=mygroup
 client.id=myAPIKey
 security.protocol=SASL_SSL
+sasl.mechanism=PLAIN
 ssl.protocol=TLSv1.2
 ssl.enabled.protocols=TLSv1.2
 ssl.truststore.type=JKS

--- a/samples/KafkaSASLSample/etc/jaas.conf
+++ b/samples/KafkaSASLSample/etc/jaas.conf
@@ -1,5 +1,5 @@
 KafkaClient {
-    com.ibm.messagehub.login.MessageHubLoginModule required
+    org.apache.kafka.common.security.plain.PlainLoginModule required
     serviceName="kafka"
     username="myusername"
     password="mypassword";

--- a/samples/KafkaSASLSample/etc/producer.properties
+++ b/samples/KafkaSASLSample/etc/producer.properties
@@ -2,6 +2,7 @@ bootstrap.servers=broker.host.1:9092,broker.host.2:9092,broker.host.3:9092
 acks=all
 client.id=myAPIKey
 security.protocol=SASL_SSL
+sasl.mechanism=PLAIN
 ssl.protocol=TLSv1.2
 ssl.enabled.protocols=TLSv1.2
 ssl.truststore.type=JKS


### PR DESCRIPTION
Based on [MessageHub doc](https://developer.ibm.com/messaging/2016/07/26/message-hub-now-runs-kafka-0-10/) recommendations, this change is to use SASL PLAIN and replace MessageHubLoginModule with PlainLoginModule.

This change fixes and simplifies the [Get Started with Streaming Analytics + Message Hub](https://www.ibm.com/blogs/bluemix/2015/10/streaming-analytics-message-hub-2/) article instructions.