### PR TITLE
avoid loading app config multiple times from PE

### DIFF
--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/common/PropertyProvider.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/common/PropertyProvider.java
@@ -12,43 +12,77 @@ import com.ibm.streamsx.messaging.i18n.Messages;
 
 // This class provides configuration data stored in PE
 public class PropertyProvider {
-	
-	private ProcessingElement pe;
-	private String configurationName;
-	private Map<String,String> configuration;
 
-	public PropertyProvider(ProcessingElement pe, String configurationName) {
-		this.pe = pe;
-		this.configurationName = configurationName;
-		this.loadConfiguration();
-		
-		if(configuration.isEmpty()) {
-			throw new IllegalArgumentException(Messages.getString("APP_CFG_NOT_FOUND_OR_EMPTY", configurationName )); //$NON-NLS-1$
-		}
-	}
-	
-	// get a property value by name
-	// reload configuration each time to get latest property value
-	public String getProperty(String name) {
-		this.loadConfiguration();
-		return configuration.get(name);
-	}
-	
-	// check if the property provider contains a certain property
-	// reload configuration each time to get latest property value
-	public boolean contains(String name) {
-		this.loadConfiguration();
-		return configuration.containsKey(name);
-	}
-	
-	// get a all properties
-	// reload configuration each time to get latest property value
-	public Map<String, String> getAllProperties() {
-		this.loadConfiguration();
-		return configuration;
-	}
-	
-	private void loadConfiguration() {
-		configuration = pe.getApplicationConfiguration(configurationName);
-	}
+    private ProcessingElement pe;
+    private String configurationName;
+    private Map<String,String> configuration = null;
+
+    public PropertyProvider(ProcessingElement pe, String configurationName) {
+        this.pe = pe;
+        this.configurationName = configurationName;
+        this.loadConfiguration();
+
+        if(configuration.isEmpty()) {
+            throw new IllegalArgumentException(Messages.getString("APP_CFG_NOT_FOUND_OR_EMPTY", configurationName )); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * get a property value by name
+     * @param name the property name
+     * @param reloadConfig if set to <tt>true</tt>, the configuration is reloaded to get the latest property value.
+     * @return The property value or <tt>null</tt> if the named property is not present.
+     */
+    public String getProperty(String name, boolean reloadConfig) {
+        if (reloadConfig) {
+            this.loadConfiguration();
+        }
+        return configuration.get(name);
+    }
+
+    /**
+     * Reload the configuration and get a property value by name
+     * @param name the property name
+     * @return The property value or <tt>null</tt> if the named property is not present.
+     */
+    public String getProperty (String name) {
+        this.loadConfiguration();
+        return configuration.get(name);
+    }
+
+    /**
+     * Checks for existence of a given property
+     * @param name the property name
+     * @param reloadConfig if set to <tt>true</tt>, the configuration is reloaded to get the latest property value.
+     * @return <tt>true</tt> if the property exists, <tt>false</tt> otherwise
+     */
+    public boolean contains(String name, boolean reloadConfig) {
+        if (reloadConfig) {
+            this.loadConfiguration();
+        }
+        return configuration.containsKey(name);
+    }
+
+    /**
+     * Reloads the configuration and checks for existence of a given property
+     * @param name the property name
+     * @return <tt>true</tt> if the property exists, <tt>false</tt> otherwise
+     */
+    public boolean contains(String name) {
+        this.loadConfiguration();
+        return configuration.containsKey(name);
+    }
+
+    /**
+     * Loads the configuration and gets all properties as a map, that maps property names to their values.
+     * @return a map that maps property names to their values
+     */
+    public Map<String, String> getAllProperties() {
+        this.loadConfiguration();
+        return configuration;
+    }
+
+    private void loadConfiguration() {
+        configuration = pe.getApplicationConfiguration(configurationName);
+    }
 }

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSConnectionHelper.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSConnectionHelper.java
@@ -445,7 +445,7 @@ class JMSConnectionHelper implements ExceptionListener {
 		}
 		
 		String userName = propertyProvider.getProperty(userPropName);
-		String password = propertyProvider.getProperty(passwordPropName);
+		String password = propertyProvider.getProperty(passwordPropName, false);
 		
 		if(this.userPrincipal == userName && this.userCredential == password) {
 			return false;

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSink.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSink.java
@@ -517,8 +517,8 @@ public class JMSSink extends AbstractOperator implements StateHandler{
 			
 			PropertyProvider provider = new PropertyProvider(checker.getOperatorContext().getPE(), appConfigName);
 			
-			String userName = provider.getProperty(userPropName);
-			String password = provider.getProperty(passwordPropName);
+			String userName = provider.getProperty(userPropName, false);
+			String password = provider.getProperty(passwordPropName, false);
 			
 			if(userName == null || userName.trim().length() == 0) {
 				logger.log(LogLevel.ERROR, "PROPERTY_NOT_FOUND_IN_APP_CONFIG", new String[] {userPropName, appConfigName}); //$NON-NLS-1$

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSource.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/jms/JMSSource.java
@@ -552,8 +552,8 @@ public class JMSSource extends ProcessTupleProducer implements StateHandler{
 			
 			PropertyProvider provider = new PropertyProvider(checker.getOperatorContext().getPE(), appConfigName);
 			
-			String userName = provider.getProperty(userPropName);
-			String password = provider.getProperty(passwordPropName);
+			String userName = provider.getProperty(userPropName, false);
+			String password = provider.getProperty(passwordPropName, false);
 			
 			if(userName == null || userName.trim().length() == 0) {
 				logger.log(LogLevel.ERROR, "PROPERTY_NOT_FOUND_IN_APP_CONFIG", new String[] {userPropName, appConfigName}); //$NON-NLS-1$

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/AbstractMqttOperator.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/AbstractMqttOperator.java
@@ -116,6 +116,8 @@ public abstract class AbstractMqttOperator extends AbstractOperator {
 			checker.setInvalidContext(
 					Messages.getString("SERVER_URI_OR_CONNECTION_MUST_BE_SET"), new Object[] {}); //$NON-NLS-1$
 		}
+	    // get a all properties
+	    // reload configuration each time to get latest property value
 
 		checker.checkExcludedParameters(PARAMNAME_SERVER_URI,
 				PARAMNAME_CONNECTION, PARAMNAME_CONNDOC);
@@ -160,8 +162,8 @@ public abstract class AbstractMqttOperator extends AbstractOperator {
 			
 			PropertyProvider provider = new PropertyProvider(checker.getOperatorContext().getPE(), appConfigName);
 			
-			String userName = provider.getProperty(userPropName);
-			String password = provider.getProperty(passwordPropName);
+			String userName = provider.getProperty(userPropName, false);
+			String password = provider.getProperty(passwordPropName, false);
 			
 			if(userName == null || userName.trim().length() == 0) {
 				checker.setInvalidContext(Messages.getString("PROPERTY_NOT_FOUND_IN_APP_CONFIG"), new Object[] {userPropName, appConfigName});	//$NON-NLS-1$

--- a/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/MqttClientWrapper.java
+++ b/com.ibm.streamsx.messaging/impl/java/src/com/ibm/streamsx/messaging/mqtt/MqttClientWrapper.java
@@ -230,7 +230,7 @@ public class MqttClientWrapper implements MqttCallback {
 		}
 		
 		String userName = propProvider.getProperty(userPropName);
-		String password = propProvider.getProperty(passwordPropName);
+		String password = propProvider.getProperty(passwordPropName, false);
 		
 		conOpt.setUserName(userName);
 		conOpt.setPassword(password.toCharArray());


### PR DESCRIPTION
Application configuration is cached in a PropertyProvider, which is initialized by the PEs applicaztion config at construction time. Every time the PropertyProvider is used, it used to reload the config. This has been changed now in the LMS and MQTT operators. To retain the old function for the deprecated operators, two access methods, which allow control of reload, have been added to the PropertyProvider class and used in the JMS and MQTT operators.