### PR TITLE
Update of Paho MQTT library and version bump

### DIFF
--- a/com.ibm.streamsx.messaging/.classpath
+++ b/com.ibm.streamsx.messaging/.classpath
@@ -4,11 +4,11 @@
 	<classpathentry exported="true" kind="con" path="com.ibm.streams.java/com.ibm.streams.operator"/>
 	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="opt/downloaded/lz4-1.3.0.jar"/>
-	<classpathentry kind="lib" path="opt/downloaded/org.eclipse.paho.client.mqttv3-1.0.1.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/slf4j-api-1.7.21.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/geronimo-jms_1.1_spec-1.1.1.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/amqp-client-5.4.3.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/snappy-java-1.1.2.6.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/kafka-clients-0.10.2.2.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/org.eclipse.paho.client.mqttv3-1.2.1.jar"/>
 	<classpathentry kind="output" path="impl/java/bin"/>
 </classpath>

--- a/com.ibm.streamsx.messaging/info.xml
+++ b/com.ibm.streamsx.messaging/info.xml
@@ -684,7 +684,7 @@ The &lt;attribute> element has three possible attributes:
      * composite types
      * xml
 </info:description>
-    <info:version>5.4.1</info:version>
+    <info:version>5.4.2</info:version>
     <info:requiredProductVersion>4.2.0.0</info:requiredProductVersion>
   </info:identity>
   <info:dependencies/>

--- a/com.ibm.streamsx.messaging/info.xml
+++ b/com.ibm.streamsx.messaging/info.xml
@@ -194,9 +194,9 @@ The following example shows connection specification that contains a &lt;JMS> el
       &lt;connection_specification name=&quot;amqConn&quot;>
         &lt;JMS initial_context=&quot;org.apache.activemq.jndi.ActiveMQInitialContextFactory&quot;
         provider_url = &quot;tcp://machinename.com:61616&quot;
-        connection_factory = &quot;ConnectionFactory&quot;/>
+        connection_factory = &quot;ConnectionFactory&quot;
         user=&quot;user1&quot;
-        password=&quot;password1&quot;
+        password=&quot;password1&quot;/>
       &lt;/connection_specification>
     &lt;/connection_specifications>
 

--- a/com.ibm.streamsx.messaging/pom-kafka-0.10.xml
+++ b/com.ibm.streamsx.messaging/pom-kafka-0.10.xml
@@ -6,7 +6,7 @@
     <groupId>com.ibm.streamsx.messaging</groupId>
     <artifactId>streamsx.messaging</artifactId>
     <packaging>jar</packaging>
-    <version>5.3.13</version>
+    <version>5.4.2</version>
     <name>com.ibm.streamsx.messaging</name>
     <repositories>
         <repository>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-            <version>1.0.1</version>
+            <version>1.2.1</version>
         </dependency>
     </dependencies>
     <build>

--- a/com.ibm.streamsx.messaging/pom-kafka-0.9.xml
+++ b/com.ibm.streamsx.messaging/pom-kafka-0.9.xml
@@ -6,7 +6,7 @@
     <groupId>com.ibm.streamsx.messaging</groupId>
     <artifactId>streamsx.messaging</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0</version>
+    <version>5.4.2</version>
     <name>com.ibm.streamsx.messaging</name>
     <repositories>
         <repository>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-            <version>1.0.1</version>
+            <version>1.2.1</version>
         </dependency>
     </dependencies>
     <build>

--- a/com.ibm.streamsx.messaging/pom.xml
+++ b/com.ibm.streamsx.messaging/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.ibm.streamsx.messaging</groupId>
     <artifactId>streamsx.messaging</artifactId>
     <packaging>jar</packaging>
-    <version>5.4.1</version>
+    <version>5.4.2</version>
     <name>com.ibm.streamsx.messaging</name>
     <repositories>
         <repository>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-            <version>1.0.1</version>
+            <version>1.2.1</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
- Update to latest snapshot version (v1.2.1) of Paho MQTT library, because of a reportet vulnerability.
- Correct error in connection document example
